### PR TITLE
Fix length unit of projected crs to match map conversion.

### DIFF
--- a/IFC 4.0/Example project location/example project location.ifc
+++ b/IFC 4.0/Example project location/example project location.ifc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c12c00c675e43fb872af8bec583c29e887e75a40c614d8585abcc2baf7590ed
-size 2959580
+oid sha256:eea1ed0ae64184b9bf324e82b8bfeb53b732db4c103a77e9653cc49e5f1651a9
+size 2959586


### PR DESCRIPTION
# General pull request

Fixes wrong position of example project location.

## Changes and improvements proposed by this pull request
- Fix file IFC4.0/Example project location/example project location.ifc:
The eastings and northings values in the IFCMAPCONVERSION are obviously in millimeters. But the IFCPROJECTEDCRS was set up with meters as units. Moving this over to millimeters will correctly position the file.